### PR TITLE
New feature: Add dorsal and ventral named views to pan_camera()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^renv$
+^renv\.lock$
 ^doc$
 ^Meta$
 ^doc$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Mainly contains a plotting function ggseg3d(),
     <doi:10.1177/2515245920928009>.
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2
 Depends: R (>= 2.10)
 LazyData: true
 LazyDataCompression: xz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: ggseg3d
 Title: Tri-Surface Mesh Plots for Brain Atlases
-Version: 1.6.3
-Authors@R: c(person("Athanasia Mo", "Mowinckel", 
-                    email = "a.m.mowinckel@psykologi.uio.no", 
-                    role = c("aut", "cre"),
-                    comment = c(ORCID = "0000-0002-5756-0223")),
-            person("Didac", "Vidal-Piñeiro", 
-                    email = "d.v.pineiro@psykologi.uio.no", 
-                    role = c("aut"),
-                    comment = c(ORCID = "0000-0001-9997-9156")))
+Version: 1.6.4
+Authors@R: c(
+    person("Athanasia Mo", "Mowinckel", , "a.m.mowinckel@psykologi.uio.no", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-5756-0223")),
+    person("Didac", "Vidal-Piñeiro", , "d.v.pineiro@psykologi.uio.no", role = "aut",
+           comment = c(ORCID = "0000-0001-9997-9156")),
+    person("Monica", "Thieu", , "mthieu@emory.edu", role = "ctb",
+           comment = c(ORCID = "0000-0002-6376-0467"))
+  )
 Description: Mainly contains a plotting function ggseg3d(), 
     and data of two standard brain atlases (Desikan-Killiany and aseg). 
     By far, the largest bit of the package is the data for each of the atlases.

--- a/R/additions.R
+++ b/R/additions.R
@@ -81,7 +81,7 @@ pan_camera <- function(p, camera, aspectratio = 1){
 
   stopifnot(is.character(camera)|is.list(camera))
 
-  views = if(class(camera) != "list"){
+  views = if(!inherits(camera, "list")){
     camera <- match.arg(camera, c("left lateral", "left medial", "left ventral", "left dorsal",
                                   "right lateral", "right medial", "right ventral", "right dorsal"))
     switch(camera,

--- a/R/additions.R
+++ b/R/additions.R
@@ -62,8 +62,8 @@ add_glassbrain <- function(p,
 #' The default position for plotly
 #' mesh plots are not satisfying for
 #' brain plots. This convenience function
-#' can pan the camera to lateral or medial
-#' view, or to custom made views if you are
+#' can pan the camera to lateral, medial, ventral,
+#' dorsal view, or to custom made views if you are
 #' plotly savvy.
 #'
 #' @param p plotly object
@@ -82,13 +82,21 @@ pan_camera <- function(p, camera, aspectratio = 1){
   stopifnot(is.character(camera)|is.list(camera))
 
   views = if(class(camera) != "list"){
-    camera <- match.arg(camera, c("left lateral", "left medial",
-                                  "right lateral", "right medial"))
+    camera <- match.arg(camera, c("left lateral", "left medial", "left ventral", "left dorsal",
+                                  "right lateral", "right medial", "right ventral", "right dorsal"))
     switch(camera,
            "left lateral" = list(eye = list(x = -2.5, y = 0, z = 0)),
            "left medial" = list(eye = list(x = 2, y = 0, z = 0)),
+           "left ventral" = list(eye = list(x = 0, y = 0, z = -2.5),
+                                 up = list(x = 0, y = 1, z = 0)),
+           "left dorsal" = list(eye = list(x = 0, y = 0, z = 2.5),
+                                up = list(x = 0, y = 1, z = 0)),
            "right lateral" = list(eye = list(x = 2, y = 0, z = 0)),
-           "right medial" = list(eye = list(x = -2.5, y = 0, z = 0))
+           "right medial" = list(eye = list(x = -2.5, y = 0, z = 0)),
+           "right ventral" = list(eye = list(x = 0, y = 0, z = -2.5),
+                                  up = list(x = 0, y = 1, z = 0)),
+           "right dorsal" = list(eye = list(x = 0, y = 0, z = 2.5),
+                                 up = list(x = 0, y = 1, z = 0))
     )
   }else{
     camera

--- a/man/ggseg3d.Rd
+++ b/man/ggseg3d.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/ggseg3d-package.R, R/ggseg3d.R
 \docType{package}
 \name{ggseg3d}
-\alias{ggseg3d}
 \alias{ggseg3d-package}
+\alias{ggseg3d}
 \title{ggseg3d: Plot brain segmentations with plotly}
 \usage{
 ggseg3d(

--- a/man/pan_camera.Rd
+++ b/man/pan_camera.Rd
@@ -20,8 +20,8 @@ plotly object
 The default position for plotly
 mesh plots are not satisfying for
 brain plots. This convenience function
-can pan the camera to lateral or medial
-view, or to custom made views if you are
+can pan the camera to lateral, medial, ventral,
+dorsal view, or to custom made views if you are
 plotly savvy.
 }
 \examples{

--- a/tests/testthat/test-camera.R
+++ b/tests/testthat/test-camera.R
@@ -32,9 +32,10 @@ test_that("pan_camera works", {
 
   expect_true("layoutAttrs" %in% names(p$x))
 
-  expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
-               list(eye = list(x = 0, y = 0, z = -2.5),
-                    up = list(x = 0, y = 1, z = 0))
+  expect_equal(
+     p$x$layoutAttrs[[1]]$scene$camera ,
+      list(eye = list(x = 0, y = 0, z = -2.5),
+             up = list(x = 0, y = 1, z = 0))
   )
 
 

--- a/tests/testthat/test-camera.R
+++ b/tests/testthat/test-camera.R
@@ -72,9 +72,10 @@ test_that("pan_camera works", {
 
   expect_true("layoutAttrs" %in% names(p$x))
 
-  expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
-               list(eye = list(x = 0, y = 0, z = -2.5),
-                    up = list(x = 0, y = 1, z = 0))
+  expect_equal(
+      p$x$layoutAttrs[[1]]$scene$camera ,
+      list(eye = list(x = 0, y = 0, z = -2.5),
+             up = list(x = 0, y = 1, z = 0))
   )
 
   p <- ggseg3d() %>%

--- a/tests/testthat/test-camera.R
+++ b/tests/testthat/test-camera.R
@@ -17,6 +17,26 @@ test_that("pan_camera works", {
                list(eye = list(x = -2.5, y = 0, z = 0))
   )
 
+  p <- ggseg3d() %>%
+    pan_camera("right dors")
+
+  expect_true("layoutAttrs" %in% names(p$x))
+
+  expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
+               list(eye = list(x = 0, y = 0, z = 2.5),
+                    up = list(x = 0, y = 1, z = 0))
+  )
+
+  p <- ggseg3d() %>%
+    pan_camera("right vent")
+
+  expect_true("layoutAttrs" %in% names(p$x))
+
+  expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
+               list(eye = list(x = 0, y = 0, z = -2.5),
+                    up = list(x = 0, y = 1, z = 0))
+  )
+
 
   p <- ggseg3d() %>%
     pan_camera("left lat")
@@ -34,6 +54,26 @@ test_that("pan_camera works", {
 
   expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
                list(eye = list(x = 2, y = 0, z = 0))
+  )
+
+  p <- ggseg3d() %>%
+    pan_camera("left dors")
+
+  expect_true("layoutAttrs" %in% names(p$x))
+
+  expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
+               list(eye = list(x = 0, y = 0, z = 2.5),
+                    up = list(x = 0, y = 1, z = 0))
+  )
+
+  p <- ggseg3d() %>%
+    pan_camera("left vent")
+
+  expect_true("layoutAttrs" %in% names(p$x))
+
+  expect_equal(p$x$layoutAttrs[[1]]$scene$camera ,
+               list(eye = list(x = 0, y = 0, z = -2.5),
+                    up = list(x = 0, y = 1, z = 0))
   )
 
   p <- ggseg3d() %>%


### PR DESCRIPTION
Hi! I recently took a look again at the ggseg family of packages to plot some results using the `ggsegGlasser` version of the Glasser 2016 multimodal parcellation atlas. As an R native, I am deeply thankful that they allow me to use ggplot logic to plot whole-brain stats, when so many brain plotting tools use such different plotting logic.

The study I'm analyzing involves modulation of high-level visual features, and we have several suprathreshold parcels in ventral temporal cortex, so I would love to be able to plot ventral views of the ggseg (2D) atlases along with the included lateral and medial views. In the past, when I needed ventral views, I went directly to the plotly viewer for the ggseg3d version of my statmap and rotated the brain and screenshotted the ventral surface, lol.

A few years ago, I was able to use `ggsegExtra` to generate atlases for additional parcellations of `ggsegSchaefer` that hadn't yet been rendered, so I figured I might try modifying ggsegExtra's behavior to allow snapshotting of ventral (and dorsal) views when building a ggseg atlas from a ggseg3d atlas, and then I could regenerate my own versions of the ggsegGlasser atlas with the additional views. 

I did some digging from ggsegExtra and found that the way you set up `ggsegExtra::make_ggseg3d_2_ggseg()` is that you call `ggseg3d::pan_camera()` with a series of named views (left/right x lateral/medial). It looked like the first step to making dorsal and ventral views snapshottable in ggsegExtra was to add named views to `ggseg3d::pan_camera()` for left/right x dorsal/ventral, so I did that by adding the relevant `switch()` matches in `pan_camera()`.

It appears to work as intended (and doesn't interfere with existing functionality)! The existing tests passed, and I added a couple tests of the new camera views in `tests/testthat/test-camera.R` in the same format as the relevant existing tests. R CMD check also passes, although there are a couple notes that I hope aren't related to any changes I made.

Please let me know what you think! I discovered that other changes in ggsegExtra and ggseg were also necessary to get extra-views atlases to render, but this ggseg3d update is the only one that doesn't depend on the others, so I figured I'd submit this one first.