### PR TITLE
install chrome for pkgdown site build

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,13 +25,26 @@ jobs:
         with:
           use-public-rspm: true
 
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown
+          extra-packages: any::pkgdown, any::webshot2, any::chromote
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        env:
+          CHROMOTE_CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: |
+          chromote::set_default_chromote_object(
+            chromote::Chromote$new(
+              browser = chromote::Chrome$new(
+                args = c(chromote::default_chrome_args(), "--no-sandbox")
+              )
+            )
+          )
+          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages


### PR DESCRIPTION
## Summary
- pkgdown CI has been failing since 2.1.0 because the walkthrough vignette calls `snapshot_brain()` (via webshot2/chromote) but Chrome was never installed in the workflow — chromote failed with `Chrome debugging port not open after 10 seconds`.
- Add `browser-actions/setup-chrome`, pull `webshot2`/`chromote` into the pkgdown dep set, and pre-configure chromote with `--no-sandbox` (GHA runners run as root, so the default Chrome sandbox refuses to start).

## Test plan
- [ ] pkgdown workflow succeeds on this branch
- [ ] Walkthrough vignette renders with snapshot images

🤖 Generated with [Claude Code](https://claude.com/claude-code)