### PR TITLE
Install the package for the pkgdown site build

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, any::webshot2, any::chromote
+          extra-packages: any::pkgdown, any::webshot2, any::chromote, local::.
           needs: website
 
       - name: Build site


### PR DESCRIPTION
## Summary

The v2.1.2 release triggered the pkgdown workflow, which **failed** in ~4.5 min:

```
Error in loadNamespace(name) : there is no package called 'ggseg3d'
```

The "Build site" step runs `pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)`. With `install = FALSE`, pkgdown expects ggseg3d to already be installed — but `extra-packages` listed only `any::pkgdown, any::webshot2, any::chromote`, so `setup-r-dependencies` installed the *dependencies* and never the package itself.

**Fix:** add `local::.` to `extra-packages` so the package is installed before the site build, matching the r-lib canonical pkgdown workflow. (This step regressed silently; the April run passed under older `setup-r-dependencies` behaviour that installed the local package implicitly.)

## Test plan

- `pkgdown.yaml` only runs on push-to-`main`, `release`, and `workflow_dispatch` — it does **not** run on PRs, so this can't be validated by PR CI. After merge I'll trigger a `workflow_dispatch` run on `main` and confirm the site builds and deploys green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)