### PR TITLE
ci: add release-on-version caller stub

### DIFF
--- a/.github/workflows/release-on-version.yaml
+++ b/.github/workflows/release-on-version.yaml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches: [main, master]
+    paths: [DESCRIPTION]
+  workflow_dispatch: # manual trigger, e.g. to backfill a missed release
+
+name: release-on-version.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ggsegverse/.github/.github/workflows/release-on-version.yaml@main


### PR DESCRIPTION
## Summary
- Adds a thin caller stub that invokes the reusable `ggsegverse/.github/.github/workflows/release-on-version.yaml@main` workflow.
- On push to `main`/`master` touching `DESCRIPTION` (or manual dispatch), it tags and creates a GitHub release when the Version is a release version (`x.y.z`); dev versions (`x.y.z.9000`) are skipped.

## Test plan
- [ ] Merge, then `workflow_dispatch` to validate the mechanism. Since `v2.1.2` is already tagged, the run should safely no-op at the "tag already exists" guard — proving the whole reusable path end-to-end with zero side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)