### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -16,7 +16,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -40,7 +40,7 @@ jobs:
       _R_CHECK_FORCE_SUGGESTS_: false
       _R_CHECK_RD_XREFS_: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install TeX Live
         run: sudo apt-get update && sudo apt-get install -y texlive-base texlive-latex-recommended texlive-fonts-recommended texlive-extra-utils
@@ -79,7 +79,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.gp.outputs.status == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/neuroconductor-release.yaml
+++ b/.github/workflows/neuroconductor-release.yaml
@@ -11,7 +11,7 @@ jobs:
   neuroconductor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.NEUROCONDUCTOR_PAT }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -25,7 +25,7 @@ jobs:
         with:
           use-public-rspm: true
 
-      - uses: browser-actions/setup-chrome@v1
+      - uses: browser-actions/setup-chrome@v2
         id: setup-chrome
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-codemeta.yaml
+++ b/.github/workflows/update-codemeta.yaml
@@ -22,7 +22,7 @@ jobs:
 
     if: "!contains(github.event.head_commit.message, 'cm-skip')"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Node 20 action runtime is deprecated on GitHub Actions. Bumps GitHub's JS actions to their Node 24 majors. Composite actions (all r-lib/actions@v2, codecov@v5, quarto, r-hub) have no node runtime and are unaffected.

Version bumps: checkout v4/v3->v6, upload-artifact v4->v6, download-artifact v4->v7, setup-python v5->v6, github-script v7->v8, deploy-pages v4->v5, create-pull-request v7->v8, setup-chrome v1->v2, codecov v4->v5, JamesIves v4.4.1/v4.5.0->v4.8.0.