### PR TITLE
ci: adopt trivial reusable workflows

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -1,9 +1,9 @@
 on:
   push:
     branches: [main, master]
-    paths: ["README.qmd"]
+    paths: ["README.Rmd"]
   pull_request:
-    paths: ["README.qmd"]
+    paths: ["README.Rmd"]
 
 name: render-readme
 


### PR DESCRIPTION
Adopt shared reusable workflows from `ggsegverse/.github`:

- **render-readme** → caller stub (reusable now renders README.Rmd, was dead on nonexistent README.qmd)