### PR TITLE
test: validate render-readme reusable (do not merge)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -128,3 +128,4 @@ European brain imaging cohorts (Lifebrain).
 **Grant agreement number:** 732592.
 
 **Call:** Societal challenges: Health, demographic change and well-being
+


### PR DESCRIPTION
Trivial README.Rmd touch to exercise the shared render-readme reusable end-to-end. Render-only (commit step is guarded to main). Will close once green.