### PR TITLE
ci: adopt pkgdown reusable

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -8,10 +8,11 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: write
+
 jobs:
   pkgdown:
-    permissions:
-      contents: write
     uses: ggsegverse/.github/.github/workflows/pkgdown.yaml@main
     with:
       use-chromote: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,56 +1,18 @@
 on:
   push:
     branches: [main, master]
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:
 
 name: pkgdown
 
-permissions: read-all
-
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: browser-actions/setup-chrome@v2
-        id: setup-chrome
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, any::webshot2, any::chromote, local::.
-          needs: website
-
-      - name: Build site
-        env:
-          CHROMOTE_CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
-        run: |
-          chromote::set_default_chromote_object(
-            chromote::Chromote$new(
-              browser = chromote::Chrome$new(
-                args = c(chromote::default_chrome_args(), "--no-sandbox")
-              )
-            )
-          )
-          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: ggsegverse/.github/.github/workflows/pkgdown.yaml@main
+    with:
+      use-chromote: true
+      extra-packages: any::pkgdown, any::webshot2, any::chromote, local::.

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,7 +1,6 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Replace copied pkgdown workflow with a caller stub for the shared reusable in ggsegverse/.github. Deploy stays push/release-guarded.