### PR TITLE
ci: adopt update-codemeta reusable

### DIFF
--- a/.github/workflows/update-codemeta.yaml
+++ b/.github/workflows/update-codemeta.yaml
@@ -8,38 +8,11 @@ on:
 
 name: update-codemeta
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update-codemeta:
-    runs-on: ubuntu-latest
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    permissions:
-      contents: write
-
-    if: "!contains(github.event.head_commit.message, 'cm-skip')"
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::codemetar, local::.
-
-      - name: Update codemeta.json
-        run: codemetar::write_codemeta()
-        shell: Rscript {0}
-
-      - name: Commit and push
-        if: github.event_name == 'push'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add codemeta.json
-          git diff --staged --quiet || (git commit -m "Update codemeta.json" && git push)
+    uses: ggsegverse/.github/.github/workflows/update-codemeta.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Adopt the shared `update-codemeta` reusable in `ggsegverse/.github` (PR #7). Regenerates `codemeta.json` from DESCRIPTION and merges via the least-privilege ggseg-bot app token (ruleset bypass, PR-merge only). Validated end-to-end on ggseg.formats (bot opened + signed-merged PR #28, zero reviews).